### PR TITLE
Clear up documentation, remove unused constant

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,33 @@ Convert your [tweets](https://www.twitter.com) to awesome fun text.
 
 ## What is a window size? 
 
-Example for a window size of 2
+The window size (also known as the order of a Markov Chain) determines the number of tokens in the prefix which are 
+examined for the search of an existing suffix. The mapping from prefix-&gt;suffix is called a dictionary. 
 
-prefix (n=2)|suffixes
+While a window size of one suffices for a small text base the textual stringency rises
+with the window size because more prefix tokens are taken into consideration. And while this CAN lead to a better
+textual stringency it also means that the word histogram MAY look totally different in terms of probable suffix
+selection. Exactly one suffix for a prefix has a general probability of p=1.0 for selection which in turn leads to
+a very high probability to re-generate already existing sentences.
+
+Given these sentences the window size the significance gets a bit clearer when you look at the two examples below.
+
+### Example for a window size of 2
+
+prefix (window size=1)|suffixes
+------|--------
+hello | \[world, again, my\]
+world | \[\]
+again | \[\]
+my | \[old, little\]
+little | \[pony\]
+old | \[friend\]
+pony | \[\]
+friend | \[\]
+
+### Example for a window size of 2
+
+prefix (window size=1)|suffixes
 ------|--------
 hello world | \[\]
 hello again | \[\]

--- a/src/de/philipppixel/tweetkov/core/TweetkovChain.java
+++ b/src/de/philipppixel/tweetkov/core/TweetkovChain.java
@@ -11,8 +11,9 @@ import java.util.logging.Logger;
  * <p>Multiple occurrences of the same word possible and desired because the selection</p>
  * probability rises later on.</p>
  * <p>
- * The window size determines (also known as the order of a Markov Chain) the structure of the dictionary (that is the
- * map from prefix-&gt;suffix). While a window size of one suffices for a small text base the textual stringency rises
+ * The window size (also known as the order of a Markov Chain) determines the number of tokens in the prefix which are
+ * examined for the search of an existing suffix. The mapping from prefix-&gt;suffix is called a dictionary.</p>
+ * <p>While a window size of one suffices for a small text base the textual stringency rises
  * with the window size because more prefix tokens are taken into consideration. And while this CAN lead to a better
  * textual stringency it also means that the word histogram MAY look totally different in terms of probable suffix
  * selection. Exactly one suffix for a prefix has a general probability of p=1.0 for selection which in turn leads to
@@ -45,7 +46,6 @@ import java.util.logging.Logger;
 public class TweetkovChain {
     public static final int DEFAULT_WINDOW_SIZE = 2;
     private static final int MAX_NUMBER_OF_WORDS_PER_SENTENCE = 32;
-    private static final int NULL_SAFE_RETRIES = 5;
     private static final String SENTENCE_DELIMITER = ".";
     private static final String WORD_DELIMITER = " ";
     private static final String EMPTY_RESULT = "";
@@ -199,6 +199,7 @@ public class TweetkovChain {
 
     /**
      * This makes the tester happy
+     *
      * @param seed this value initializes the pseudo-random generator. For the same seed the generated values are
      *             predictable, thus enabling testing.
      */


### PR DESCRIPTION
The documentation did not differentiate between the window sizes (per
example). This commit adds some more commentary about how the changing
of the window sizes work the dictionary

During this, a unused constant came to my attention. In the spirit of
Boyscouting this reference was removed.