### PR TITLE
Pxlphile/remove re duplication during generation

### DIFF
--- a/src/de/philipppixel/tweetkov/LinekovRunner.java
+++ b/src/de/philipppixel/tweetkov/LinekovRunner.java
@@ -38,7 +38,7 @@ public class LinekovRunner {
     }
 
     private void makeItWeird() {
-//        app.printHistogram();
+//        app.createHistogram();
 
         for (int i = 0; i < NUMBER_OF_SENTENCES; i++) {
             String sentence = app.generate();

--- a/src/de/philipppixel/tweetkov/TweetkovRunner.java
+++ b/src/de/philipppixel/tweetkov/TweetkovRunner.java
@@ -97,10 +97,10 @@ public class TweetkovRunner {
     }
 
     private void makeItWeird() {
-//        app.printHistogram();
+//        app.createHistogram();
 
         for (int i = 0; i < NUMBER_OF_SENTENCES; i++) {
-            String sentence = app.generate();
+            String sentence = app.generateWithoutDuplicates();
             if(sentence.split(" ").length < 5) {
                 i--;
                 continue;

--- a/src/de/philipppixel/tweetkov/core/Sentence.java
+++ b/src/de/philipppixel/tweetkov/core/Sentence.java
@@ -1,0 +1,80 @@
+package de.philipppixel.tweetkov.core;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This class provides a way to avoid original fragments.
+ * <p>
+ * Sentences are called <code>duplicates</code> when they consist of transitions that would result in a text that is
+ * fully or partially an original tweet. Sentences are called <code>alternatives</code> when they used at least one
+ * different tokens than the original tweet.
+ * <p>
+ * Currentely, after the training there is no way to know which transitions the original sentence in real life took.
+ * There is still a high chance to render duplicates that are marked as alternative.
+ */
+class Sentence {
+    private static final String SENTENCE_DELIMITER = ".";
+    private final String wordDelimiter;
+    private List<String> tokens = new ArrayList<>();
+    private List<Boolean> duplicateLedger = new ArrayList<>();
+
+    Sentence(String wordDelimiter) {
+        this.wordDelimiter = wordDelimiter;
+    }
+
+    /**
+     * Returns true if all transitions indicate that there was only one choice to generate this sentence thus rendering
+     * a duplicate. If at least one alternative transition was found this sentence counts as alternative.
+     * <p>
+     * Please note that after the training there is no way to know which transitions the original sentence in real life
+     * took. So there is still a high chance to render duplicates that are marked as alternative.
+     *
+     * @return true if all transitions indicate that there was only one choice to generate this sentence thus rendering
+     * a duplicate
+     */
+    boolean isDuplicate() {
+        for (boolean isAlternative : duplicateLedger) {
+            if (isAlternative) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    void addBridge(String suffix, Transition transition) {
+        if (suffix.isEmpty()) {
+            return;
+        }
+
+        if (tokens.isEmpty()) {
+            addStartPrefix(transition.getPrefix());
+        }
+        this.tokens.add(suffix);
+
+        boolean isAlternative = transition.getUniqueSuffixCount() > 1;
+        this.duplicateLedger.add(isAlternative);
+    }
+
+    private void addStartPrefix(Prefix prefix) {
+        this.tokens.add(prefix.toString());
+    }
+
+    /**
+     * returns the generated sentence as string, ending with {@link #SENTENCE_DELIMITER}.
+     *
+     * @return the generated sentence, ending with {@link #SENTENCE_DELIMITER}.
+     */
+    String create() {
+        return toString() + SENTENCE_DELIMITER;
+    }
+
+    @Override
+    public String toString() {
+        String result = "";
+        for (String token : tokens) {
+            result += token + wordDelimiter;
+        }
+        return result.trim();
+    }
+}

--- a/src/de/philipppixel/tweetkov/core/Transition.java
+++ b/src/de/philipppixel/tweetkov/core/Transition.java
@@ -1,0 +1,88 @@
+package de.philipppixel.tweetkov.core;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+
+/**
+ * This class maps the possible transitions of prefix to any number of suffixes. While it is possible to append any
+ * number of suffixes, the prefix is fixed once the transition is created. <p>This class is not thread-safe.</p>
+ */
+class Transition {
+
+    private final Prefix prefix;
+    private List<String> suffixes = new ArrayList<>();
+    private Random random = new Random();
+
+    /**
+     * Creates a transition. The prefix will be fixed to this transition and cannot be changed.
+     *
+     * @param prefix the prefix identifies the start of the transition. It must not be <code>null</code>
+     */
+    Transition(Prefix prefix) {
+        if (prefix == null) {
+            throw new IllegalArgumentException("Cannot create Transition. Prefix must not be null");
+        }
+        this.prefix = prefix;
+    }
+
+    /**
+     * maps the suffix to the prefix. The same suffix can be mapped several times which increases its overall
+     * probability of being picked during the sentence generation.
+     *
+     * @param suffixToken any string which will be trimmed. An exception will be thrown if <code>null</code>. Empty
+     *                    strings are allowed because the algorithm may have arrived at the last prefix (usually the end
+     *                    of the sentence).
+     */
+    void mapSuffix(String suffixToken) {
+        if (suffixToken == null) {
+            throw new IllegalArgumentException("Could not map suffix to prefix '" + prefix
+                    + "'. Suffix must not be empty or null");
+        }
+
+        suffixes.add(suffixToken);
+    }
+
+    /**
+     * returns the current suffixes.
+     *
+     * @return the current collection of suffixes. The collection is unmodifiable. If you want to add a suffix, please
+     * use {@link #mapSuffix(String)}.
+     */
+    Collection<String> getSuffixes() {
+        return Collections.unmodifiableCollection(suffixes);
+    }
+
+    /**
+     * returns the prefix for this transition
+     *
+     * @return the prefix for this transition
+     */
+    Prefix getPrefix() {
+        return prefix;
+    }
+
+    int getUniqueSuffixCount() {
+        return new HashSet<>(suffixes).size();
+    }
+
+    private int getTotalSuffixCount() {
+        return suffixes.size();
+    }
+
+    String getRandomSuffix() {
+        if (getTotalSuffixCount() == 0) {
+            return "";
+        }
+
+        int selectedSuffixIndex = this.random.nextInt(getTotalSuffixCount());
+        return suffixes.get(selectedSuffixIndex);
+    }
+
+    void initializeRandom(long seed) {
+        random.setSeed(seed);
+    }
+}

--- a/src/de/philipppixel/tweetkov/core/TransitionRepository.java
+++ b/src/de/philipppixel/tweetkov/core/TransitionRepository.java
@@ -1,0 +1,89 @@
+package de.philipppixel.tweetkov.core;
+
+import java.util.*;
+
+/**
+ * This class organizes the TweetkovChain dictionary and helps to decouple for the storage and retrieve part.
+ */
+class TransitionRepository {
+    private static final int ORIGINAL_START_PREFIX_PROBABILITY_IN_PERCENT = 67;
+
+    /**
+     * Provides efficient access to all prefixes. Although transitions keep their own prefixes iterating all transitions
+     * is not efficient enough to quickly get all prefixes.
+     */
+    private Map<Prefix, Transition> prefixToTransitions = new HashMap<>();
+    private final List<Prefix> startPrefixes = new ArrayList<>();
+    private Random random = new Random();
+
+    void train(Prefix prefix, String suffix) {
+        Transition mapping = get(prefix);
+        if (mapping == null) {
+            mapping = new Transition(prefix);
+            prefixToTransitions.put(prefix, mapping);
+        }
+        mapping.mapSuffix(suffix);
+    }
+
+    void trainAsStartPrefix(Prefix prefix, String suffix) {
+        train(prefix, suffix);
+        addToStartTokens(prefix);
+    }
+
+    private void addToStartTokens(Prefix prefix) {
+        startPrefixes.add(prefix);
+    }
+
+    Transition get(Prefix prefix) {
+        return prefixToTransitions.get(prefix);
+    }
+
+    Collection<Transition> getAllTransitions() {
+        return prefixToTransitions.values();
+
+    }
+
+    String getRandomSuffix(Prefix prefix) {
+        Transition transition = prefixToTransitions.get(prefix);
+        if (transition == null) {
+            return "";
+        }
+
+        return transition.getRandomSuffix();
+    }
+
+    void initializeRandomSeed(long seed) {
+        random.setSeed(seed);
+
+        for (Transition transition : prefixToTransitions.values()) {
+            transition.initializeRandom(seed);
+        }
+    }
+
+    Prefix getRandomStartPrefix() {
+        if(startPrefixes.isEmpty()) {
+            throw new IllegalStateException("Cannot return start prefix because there are no prefixes yet.");
+        }
+        int keyIndex = random.nextInt(startPrefixes.size());
+        return startPrefixes.get(keyIndex);
+    }
+
+    Prefix getRandomPrefix() {
+        if(prefixToTransitions.isEmpty()) {
+            throw new IllegalStateException("Cannot return prefix because there are no prefixes yet.");
+        }
+
+        Prefix[] prefixes = prefixToTransitions.keySet().toArray(new Prefix[startPrefixes.size()]);
+        int keyIndex = random.nextInt(prefixes.length);
+        return prefixes[keyIndex];
+    }
+
+    Prefix getFirstPrefixToken() {
+        int hundredPercent = 100;
+        int originalStartWord = random.nextInt(hundredPercent);
+        if (originalStartWord <= ORIGINAL_START_PREFIX_PROBABILITY_IN_PERCENT) {
+            return getRandomStartPrefix();
+        }
+        return getRandomPrefix();
+    }
+}

--- a/test/de/philipppixel/tweetkov/core/PrefixTest.java
+++ b/test/de/philipppixel/tweetkov/core/PrefixTest.java
@@ -88,13 +88,32 @@ class PrefixTest {
         prefix2.appendToken("lowercase");
         prefix2.appendToken("lowercase1"); // note the extra char
 
-        boolean actual = sut.equals(prefix2);
+        boolean actual = sut.hashCode() == prefix2.hashCode();
 
-        assertThat(actual).as("Prefixes should not have same hashcode: %s <=> %s", sut, prefix2).isFalse();
+        assertThat(actual)
+                .as("Prefixes should not have same hashcode: %s <=> %s", sut.hashCode(), prefix2.hashCode())
+                .isFalse();
     }
 
     @Test
-    void hashcodeShouldBeEqualForEqualPrefixes() {
+    void hashcodeForSameTokensShouldBeEqual() {
+        Prefix sut = new Prefix(2);
+        sut.appendToken("lowercase");
+        sut.appendToken("lowercase");
+
+        Prefix prefix2 = new Prefix(2);
+        prefix2.appendToken("lowercase");
+        prefix2.appendToken("lowercase");
+
+        boolean actual = sut.equals(prefix2);
+
+        assertThat(actual)
+                .as("Prefixes should have same hashcode: %s <=> %s", sut.hashCode(), prefix2.hashCode())
+                .isTrue();
+    }
+
+    @Test
+    void hashcodeShouldIgnoreCase() {
         Prefix sut = new Prefix(2);
         sut.appendToken("lowercase");
         sut.appendToken("lowercase");
@@ -105,7 +124,9 @@ class PrefixTest {
 
         boolean actual = sut.equals(prefix2);
 
-        assertThat(actual).as("Prefixes should have same hashcode: %s <=> %s", sut, prefix2).isTrue();
+        assertThat(actual)
+                .as("Prefixes should have same hashcode: %s <=> %s", sut.hashCode(), prefix2.hashCode())
+                .isTrue();
     }
 
     @Test

--- a/test/de/philipppixel/tweetkov/core/SentenceTest.java
+++ b/test/de/philipppixel/tweetkov/core/SentenceTest.java
@@ -1,0 +1,57 @@
+package de.philipppixel.tweetkov.core;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SentenceTest {
+
+    private static final String WORD_DELIMITER = " ";
+    private Sentence sut = new Sentence(WORD_DELIMITER);
+
+    @Test
+    void addPrefixShouldResultInDuplicate() {
+        // given
+        Prefix prefix = prefix("you", "are");
+
+        Transition transition = new Transition(prefix);
+        transition.mapSuffix("so");
+
+        sut.addBridge("so", transition);
+
+        // when
+        boolean actual = sut.isDuplicate();
+
+        // then
+        assertThat(actual)
+                .as("Expected the sentence to be a duplicate: %s", sut.toString())
+                .isTrue();
+    }
+
+    @Test
+    void addPrefixShouldResultInAlternative() {
+// given
+        Prefix prefix = prefix("you", "are");
+
+        Transition transition = new Transition(prefix);
+        transition.mapSuffix("so");
+        transition.mapSuffix("not");
+
+        sut.addBridge("so", transition);
+
+        // when
+        boolean actual = sut.isDuplicate();
+
+        assertThat(actual)
+                .as("Expected the sentence to be an alternative: %s", sut.toString())
+                .isFalse();
+    }
+
+    private Prefix prefix(String... tokens) {
+        Prefix prefix = new Prefix(tokens.length);
+        for (String token : tokens) {
+            prefix.appendToken(token);
+        }
+        return prefix;
+    }
+}

--- a/test/de/philipppixel/tweetkov/core/TransitionRepositoryTest.java
+++ b/test/de/philipppixel/tweetkov/core/TransitionRepositoryTest.java
@@ -1,0 +1,174 @@
+package de.philipppixel.tweetkov.core;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class TransitionRepositoryTest {
+
+    private TransitionRepository sut = new TransitionRepository();
+
+    @Test
+    void trainShouldAddMappingsToRepository() {
+        // given
+        Prefix prefix = new Prefix(2);
+        prefix.appendToken("My");
+        prefix.appendToken("Little");
+
+        // when
+        sut.train(prefix, "Pony");
+
+        // then
+        Prefix prefixToSearch = prefix("My", "Little");
+        assertThat(sut.get(prefixToSearch).getSuffixes()).containsExactly("Pony");
+    }
+
+    @Test
+    void getRandomStartPrefixShouldReturnRandomPrefixesWithoutError() {
+        // given
+        Prefix prefix = new Prefix(2);
+        prefix.appendToken("Hello");
+        prefix.appendToken("World");
+        sut.trainAsStartPrefix(prefix, "Something");
+
+        Prefix prefix2 = new Prefix(2);
+        prefix2.appendToken("Hello");
+        prefix2.appendToken("Pluto");
+        sut.trainAsStartPrefix(prefix2, "SomethingElse");
+
+        sut.initializeRandomSeed(6); // pretty random, eh?
+
+        // when
+        List<Prefix> actual = new ArrayList<>();
+        for (int i = 0; i < 11; i++) {
+            Prefix actualPrefix = sut.getRandomStartPrefix();
+            actual.add(actualPrefix);
+        }
+
+        // then
+        Prefix world = prefix("Hello", "World");
+        Prefix pluto = prefix("Hello", "Pluto");
+
+        Prefix[] oracleOfEleven = {pluto, world, pluto, world, pluto, pluto, world, world, world, pluto, pluto};
+
+        assertThat(actual).containsExactly(oracleOfEleven);
+    }
+
+    @Test
+    void getRandomStartPrefixShouldThrowExceptionForUntrainedPrefixes() {
+        // when & then
+        assertThrows(IllegalStateException.class, () -> sut.getRandomStartPrefix());
+    }
+
+    @Test
+    void getRandomPrefixShouldThrowExceptionForUntrainedPrefixes() {
+        // when & then
+        assertThrows(IllegalStateException.class, () -> sut.getRandomPrefix());
+    }
+
+    @Test
+    void getRandomPrefixShouldReturnPrefixesFromBothStartListAndDeeperPrefixes() {
+        // given
+        Prefix startPrefix1 = new Prefix(2);
+        startPrefix1.appendToken("Hello");
+        startPrefix1.appendToken("World");
+        sut.trainAsStartPrefix(startPrefix1, "Europe");
+
+        Prefix deeper1 = startPrefix1.shiftWithSuffix("Europe");
+        sut.train(deeper1, "Germany"); // World Europe -> Germany
+
+        Prefix deeper2 = deeper1.shiftWithSuffix("Germany");
+        sut.train(deeper2, "Berlin"); // Europe Germany -> Berlin
+
+        Prefix startPrefix2 = new Prefix(2);
+        startPrefix2.appendToken("Hello");
+        startPrefix2.appendToken("Pluto");
+        sut.trainAsStartPrefix(startPrefix2, "Tombaugh");
+
+        Prefix deeper3 = startPrefix2.shiftWithSuffix("Tombaugh");
+        sut.train(deeper3, "SputnikPlanum");  // Pluto Tombaugh -> Sputnik
+
+        Prefix deeper4 = deeper3.shiftWithSuffix("SputnikPlanum");
+        sut.train(deeper4, "AstridColles"); // Tombaugh Sputnik -> Astrid
+
+        sut.initializeRandomSeed(8); // pretty random, eh?
+
+        // when
+        List<Prefix> actual = new ArrayList<>();
+        for (int i = 0; i < 11; i++) {
+            Prefix actualPrefix = sut.getRandomPrefix();
+            actual.add(actualPrefix);
+        }
+
+        // then
+        Prefix hellow = prefix("Hello", "World");
+        Prefix world = prefix("World", "Europe");
+        Prefix europe = prefix("Europe", "Germany");
+        Prefix hellop = prefix("Hello", "Pluto");
+        Prefix pluto = prefix("Pluto", "Tombaugh");
+        Prefix tombaugh = prefix("Tombaugh", "SputnikPlanum");
+
+        Prefix[] oracleOfEleven = {world, world, world, europe, pluto, tombaugh, hellow, hellop, hellop, pluto, pluto};
+
+        assertThat(actual).containsExactly(oracleOfEleven);
+    }
+
+    @Test
+    void test_getStartPrefixToken() {
+        // given
+        Prefix startPrefix1 = new Prefix(2);
+        startPrefix1.appendToken("Hello");
+        startPrefix1.appendToken("World");
+        sut.trainAsStartPrefix(startPrefix1, "Europe");
+
+        Prefix inner1 = startPrefix1.shiftWithSuffix("Europe");
+        sut.train(inner1, "Germany"); // World Europe -> Germany
+
+        Prefix inner2 = inner1.shiftWithSuffix("Germany");
+        sut.train(inner2, "Berlin"); // Europe Germany -> Berlin
+
+        Prefix startPrefix2 = new Prefix(2);
+        startPrefix2.appendToken("Hello");
+        startPrefix2.appendToken("Pluto");
+        sut.trainAsStartPrefix(startPrefix2, "Tombaugh");
+
+        Prefix inner3 = startPrefix2.shiftWithSuffix("Tombaugh");
+        sut.train(inner3, "SputnikPlanum");  // Pluto Tombaugh -> Sputnik
+
+        Prefix inner4 = inner3.shiftWithSuffix("SputnikPlanum");
+        sut.train(inner4, "AstridColles"); // Tombaugh Sputnik -> Astrid
+
+        sut.initializeRandomSeed(5); // pretty random, eh?
+
+        // when
+        List<Prefix> actual = new ArrayList<>();
+        for (int i = 0; i < 11; i++) {
+            Prefix actualPrefix = sut.getFirstPrefixToken();
+            actual.add(actualPrefix);
+        }
+
+        // then
+        Prefix hellow = prefix("Hello", "World");
+        Prefix world = prefix("World", "Europe");
+        Prefix europe = prefix("Europe", "Germany");
+        Prefix hellop = prefix("Hello", "Pluto");
+        Prefix tombaugh = prefix("Tombaugh", "SputnikPlanum");
+
+        // expect a 1/3 + 2/3 distribution of start prefix and inner prefix
+        Prefix[] oracleOfEleven = {world, tombaugh, hellop, hellop, hellow, hellop, hellow, hellop, europe, hellop, hellow};
+
+        assertThat(actual).containsExactly(oracleOfEleven);
+    }
+
+    private Prefix prefix(String... tokens) {
+        Prefix p = new Prefix(tokens.length);
+        for (String token : tokens) {
+            p.appendToken(token);
+        }
+        return p;
+    }
+}

--- a/test/de/philipppixel/tweetkov/core/TransitionTest.java
+++ b/test/de/philipppixel/tweetkov/core/TransitionTest.java
@@ -1,0 +1,175 @@
+package de.philipppixel.tweetkov.core;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class TransitionTest {
+
+    @Test
+    void mapSuffixShouldAddAnotherSuffix() {
+        // given
+        Prefix prefix = new Prefix(1);
+        prefix.appendToken("hello");
+        Transition sut = new Transition(prefix);
+
+        // when
+        sut.mapSuffix("world");
+
+        // then
+        assertThat(sut.getSuffixes()).contains("world");
+    }
+
+    @Test
+    void mapSuffixShouldAddSameSuffixSeveralTime() {
+        // given
+        Prefix prefix = new Prefix(1);
+        prefix.appendToken("hello");
+        Transition sut = new Transition(prefix);
+
+        // when
+        sut.mapSuffix("world");
+        sut.mapSuffix("world");
+
+        // then
+        assertThat(sut.getSuffixes()).containsOnly("world");
+    }
+
+    @Test
+    void mapSuffixShouldHandleDifferentSuffixes() {
+        // given
+        Prefix prefix = new Prefix(1);
+        prefix.appendToken("hello");
+        Transition sut = new Transition(prefix);
+
+        // when
+        sut.mapSuffix("world");
+        sut.mapSuffix("kitty");
+        sut.mapSuffix("flower");
+        sut.mapSuffix("FLOWER");
+        sut.mapSuffix("Flower");
+        sut.mapSuffix("world");
+
+        // then
+        assertThat(sut.getSuffixes())
+                .containsOnly("world", "kitty", "flower", "FLOWER", "Flower");
+    }
+
+    @Test
+    void constructorShouldRejectNull() {
+        assertThrows(IllegalArgumentException.class, () -> new Transition(null));
+    }
+
+    @Test
+    void mappingShouldReturnUniqueSuffixCountForSameSuffix() {
+        Prefix prefix = new Prefix(1);
+        prefix.appendToken("Bon jour");
+        Transition sut = new Transition(prefix);
+
+        // when
+        sut.mapSuffix("world");
+        sut.mapSuffix("world");
+        sut.mapSuffix("world");
+        int actual = sut.getUniqueSuffixCount();
+
+        // then
+        assertThat(actual).isEqualTo(1);
+    }
+
+    @Test
+    void mappingShouldReturnUniqueSuffixCountForDifferentSuffixes() {
+        Prefix prefix = new Prefix(1);
+        prefix.appendToken("Hello");
+        Transition sut = new Transition(prefix);
+
+        // when
+        sut.mapSuffix("Kitty");
+        sut.mapSuffix("is");
+        sut.mapSuffix("world");
+        int actual = sut.getUniqueSuffixCount();
+
+        // then
+        assertThat(actual).isEqualTo(3);
+    }
+
+    @Test
+    void getRandomSuffixShouldReturnEmptyStringForNoSuffix() {
+        Prefix prefix = new Prefix(1);
+        prefix.appendToken("Xylophone");
+        Transition sut = new Transition(prefix);
+
+        // then
+        String actual = sut.getRandomSuffix();
+
+        assertThat(actual).isEmpty();
+    }
+
+    @Test
+    void getRandomSuffixShouldReturnOnlySuffix() {
+        Prefix prefix = new Prefix(1);
+        prefix.appendToken("Xylophone");
+        Transition sut = new Transition(prefix);
+        sut.mapSuffix("Zoo");
+
+        // then
+        String actual = sut.getRandomSuffix();
+
+        assertThat(actual).isEqualTo("Zoo");
+    }
+
+    @Test
+    void calculateSuffixShouldReturnTheOnlySuffix() {
+        Prefix prefix = new Prefix(1);
+        prefix.appendToken("Xylophone");
+        Transition sut = new Transition(prefix);
+        sut.mapSuffix("Zoo");
+
+        // then
+        Collection<String> actual = sut.getSuffixes();
+
+        assertThat(actual).hasSize(1).containsOnly("Zoo");
+    }
+
+    @Test
+    void calculateSuffixShouldReturnAveragelyDistributedSuffixes() {
+        Prefix prefix = new Prefix(1);
+        prefix.appendToken("Xylophone");
+        Transition sut = new Transition(prefix);
+        sut.initializeRandom(1);
+
+        sut.mapSuffix("Wolperdinger");
+        sut.mapSuffix("Xantylope");
+        sut.mapSuffix("York");
+        sut.mapSuffix("Zoo");
+
+        // then
+        List<String> actual = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            String suffix = sut.getRandomSuffix();
+            actual.add(suffix);
+        }
+
+        String w = "Wolperdinger";
+        String x = "Xantylope";
+        String y = "York";
+        String z = "Zoo";
+
+        String[] oracleOfEleven = {y, w, x, x, w, w, x, y, z, y};
+        assertThat(actual).containsExactlyInAnyOrder(oracleOfEleven);
+    }
+
+    @Test
+    void mapSuffixShouldThrowAnException_whiteSpaceOrNull() {
+        Prefix prefix = new Prefix(1);
+        prefix.appendToken("Error");
+        Transition sut = new Transition(prefix);
+
+        // when & then
+        assertThrows(IllegalArgumentException.class, () -> sut.mapSuffix(null));
+    }
+}

--- a/test/de/philipppixel/tweetkov/core/TweetkovChainTest.java
+++ b/test/de/philipppixel/tweetkov/core/TweetkovChainTest.java
@@ -3,10 +3,7 @@ package de.philipppixel.tweetkov.core;
 import org.assertj.core.util.Lists;
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -23,15 +20,16 @@ class TweetkovChainTest {
         sut.train(input);
 
         // then
-        Map<Prefix, List<String>> actualTraining = sut.getTrainingMap();
-        assertThat(actualTraining).isNotNull();
+        TransitionRepository repo = sut.getTransitions();
+        assertThat(repo).isNotNull();
 
         Prefix expectedPrefix = new Prefix(2);
         expectedPrefix.appendToken("First");
         expectedPrefix.appendToken("Second");
+        Collection<String> actualSuffixes = repo.get(expectedPrefix).getSuffixes();
+
         ArrayList<String> expectedSuffix = Lists.newArrayList("Third");
-        List<String> actualSuffix = actualTraining.get(expectedPrefix);
-        assertThat(actualSuffix).isEqualTo(expectedSuffix);
+        assertThat(actualSuffixes).hasSize(1).containsAll(expectedSuffix);
     }
 
     @Test
@@ -44,20 +42,22 @@ class TweetkovChainTest {
         sut.train(input);
 
         // then
-        Map<Prefix, List<String>> actualTraining = sut.getTrainingMap();
+        TransitionRepository actualTraining = sut.getTransitions();
         assertThat(actualTraining).isNotNull();
 
         Prefix expectedPrefix1 = new Prefix(1);
         expectedPrefix1.appendToken("First");
+        Collection<String> actualSuffixes = actualTraining.get(expectedPrefix1).getSuffixes();
+
         ArrayList<String> expectedSuffix = Lists.newArrayList("Second");
-        List<String> actualSuffix = actualTraining.get(expectedPrefix1);
-        assertThat(actualSuffix).isEqualTo(expectedSuffix);
+        assertThat(actualSuffixes).hasSize(1).containsAll(expectedSuffix);
 
         Prefix expectedPrefix2 = new Prefix(1);
         expectedPrefix2.appendToken("Second");
+        Collection<String> actualSuffixes2 = actualTraining.get(expectedPrefix2).getSuffixes();
+
         ArrayList<String> expectedSuffix2 = Lists.newArrayList("Third");
-        List<String> actualSuffix2 = actualTraining.get(expectedPrefix2);
-        assertThat(actualSuffix2).isEqualTo(expectedSuffix2);
+        assertThat(actualSuffixes2).hasSize(1).containsAll(expectedSuffix2);
     }
 
     @Test
@@ -69,15 +69,16 @@ class TweetkovChainTest {
         sut.train(input);
 
         // then
-        Map<Prefix, List<String>> actual = sut.getTrainingMap();
-        assertThat(actual).isNotNull().hasSize(7);
-        assertThat(actual.get(createPrefix_WS2("now", "he"))).isEqualTo(Lists.newArrayList("is"));
-        assertThat(actual.get(createPrefix_WS2("he", "is"))).isEqualTo(Lists.newArrayList("gone", "gone"));
-        assertThat(actual.get(createPrefix_WS2("is", "gone"))).isEqualTo(Lists.newArrayList("she", "for"));
-        assertThat(actual.get(createPrefix_WS2("gone", "she"))).isEqualTo(Lists.newArrayList("said"));
-        assertThat(actual.get(createPrefix_WS2("she", "said"))).isEqualTo(Lists.newArrayList("he"));
-        assertThat(actual.get(createPrefix_WS2("said", "he"))).isEqualTo(Lists.newArrayList("is"));
-        assertThat(actual.get(createPrefix_WS2("gone", "for"))).isEqualTo(Lists.newArrayList("good"));
+        TransitionRepository actual = sut.getTransitions();
+        assertThat(actual).isNotNull();
+        assertThat(actual.getAllTransitions()).hasSize(7);
+        assertThat(actual.get(createPrefix_WS2("now", "he")).getSuffixes()).containsExactly("is");
+        assertThat(actual.get(createPrefix_WS2("he", "is")).getSuffixes()).containsExactly("gone", "gone");
+        assertThat(actual.get(createPrefix_WS2("is", "gone")).getSuffixes()).containsExactly("she", "for");
+        assertThat(actual.get(createPrefix_WS2("gone", "she")).getSuffixes()).containsExactly("said");
+        assertThat(actual.get(createPrefix_WS2("she", "said")).getSuffixes()).containsExactly("he");
+        assertThat(actual.get(createPrefix_WS2("said", "he")).getSuffixes()).containsExactly("is");
+        assertThat(actual.get(createPrefix_WS2("gone", "for")).getSuffixes()).containsExactly("good");
     }
 
     @Test
@@ -90,15 +91,16 @@ class TweetkovChainTest {
         sut.train(input);
 
         // then
-        Map<Prefix, List<String>> actual = sut.getTrainingMap();
-        assertThat(actual).isNotNull().hasSize(7);
-        assertThat(actual.get(createPrefix_WS1("now"))).isEqualTo(Lists.newArrayList("he"));
-        assertThat(actual.get(createPrefix_WS1("he"))).isEqualTo(Lists.newArrayList("is", "is"));
-        assertThat(actual.get(createPrefix_WS1("is"))).isEqualTo(Lists.newArrayList("gone", "gone"));
-        assertThat(actual.get(createPrefix_WS1("gone"))).isEqualTo(Lists.newArrayList("she", "for"));
-        assertThat(actual.get(createPrefix_WS1("she"))).isEqualTo(Lists.newArrayList("said"));
-        assertThat(actual.get(createPrefix_WS1("said"))).isEqualTo(Lists.newArrayList("he"));
-        assertThat(actual.get(createPrefix_WS1("for"))).isEqualTo(Lists.newArrayList("good"));
+        TransitionRepository actual = sut.getTransitions();
+        assertThat(actual).isNotNull();
+        assertThat(actual.getAllTransitions()).hasSize(7);
+        assertThat(actual.get(prefix_WS1("now")).getSuffixes()).containsExactly("he");
+        assertThat(actual.get(prefix_WS1("he")).getSuffixes()).containsExactly("is", "is");
+        assertThat(actual.get(prefix_WS1("is")).getSuffixes()).containsExactly("gone", "gone");
+        assertThat(actual.get(prefix_WS1("gone")).getSuffixes()).containsExactly("she", "for");
+        assertThat(actual.get(prefix_WS1("she")).getSuffixes()).containsExactly("said");
+        assertThat(actual.get(prefix_WS1("said")).getSuffixes()).containsExactly("he");
+        assertThat(actual.get(prefix_WS1("for")).getSuffixes()).containsExactly("good");
     }
 
     @Test
@@ -108,24 +110,25 @@ class TweetkovChainTest {
         List<String> input = Collections.singletonList("now he is gone she said he is gone for good");
         sut.train(input);
         sut.initializeRandom(0);
+        String newline = "\n";
 
         String actual = "";
         // when
         for (int i = 0; i < 10; i++) {
-            actual += sut.generate();
+            actual += sut.generate() + newline;
         }
 
         // then
-        String expected = "now he is gone she said he is gone she said he is gone for good." +
-                "gone she said he is gone she said he is gone she said he is gone for good." +
-                "now he is gone for good." +
-                "now he is gone for good." +
-                "now he is gone for good." +
-                "now he is gone for good." +
-                "now he is gone she said he is gone she said he is gone for good." +
-                "for good." +
-                "now he is gone she said he is gone for good." +
-                "now he is gone she said he is gone she said he is gone she said he is gone for good.";
+        String expected = "now he is gone for good.\n" +
+                "now he is gone for good.\n" +
+                "now he is gone she said he is gone for good.\n" +
+                "now he is gone for good.\n" +
+                "now he is gone she said he is gone for good.\n" +
+                "for good.\n" +
+                "for good.\n" +
+                "she said he is gone she said he is gone for good.\n" +
+                "she said he is gone for good.\n" +
+                "now he is gone she said he is gone she said he is gone she said he is gone for good.\n";
         assertThat(actual).isEqualTo(expected);
     }
 
@@ -136,24 +139,25 @@ class TweetkovChainTest {
         List<String> input = Collections.singletonList("now he is gone she said he is gone for good");
         sut.train(input);
         sut.initializeRandom(987654321);
+        String newline = "\n";
 
         String actual = "";
         // when
         for (int i = 0; i < 10; i++) {
-            actual += sut.generate();
+            actual += sut.generate() + newline;
         }
 
         // then
-        String expected = "now he is gone she said he is gone she said he is gone she said he is gone for good." +
-                "now he is gone she said he is gone for good." +
-                "now he is gone for good." +
-                "now he is gone she said he is gone she said he is gone she said he is gone she said he is gone for good." +
-                "gone for good." +
-                "is gone for good." +
-                "now he is gone for good." +
-                "now he is gone for good." +
-                "now he is gone she said he is gone she said he is gone she said he is gone she said he is gone for good." +
-                "now he is gone she said he is gone for good.";
+        String expected = "now he is gone she said he is gone for good.\n" +
+                "now he is gone for good.\n" +
+                "now he is gone she said he is gone she said he is gone she said he is gone for good.\n" +
+                "gone for good.\n" +
+                "now he is gone she said he is gone she said he is gone she said he is gone for good.\n" +
+                "now he is gone she said he is gone she said he is gone for good.\n" +
+                "now he is gone she said he is gone she said he is gone for good.\n" +
+                "now he is gone she said he is gone she said he is gone for good.\n" +
+                "he is gone for good.\n" +
+                "now he is gone for good.\n";
         assertThat(actual).isEqualTo(expected);
     }
 
@@ -170,12 +174,72 @@ class TweetkovChainTest {
         // given
         List<String> input = Collections.singletonList("now he is gone she said he is gone for good");
         sut.train(input);
+        sut.initializeRandom(0);
 
         // when
         String actual = sut.generate();
 
         // then
         assertThat(actual).matches("[a-zA-Z]+( [a-zA-Z]+)+ ?\\.");
+    }
+
+    @Test
+    void generateSentenceShouldCreateDuplicateSentence() {
+        // given
+        List<String> input = Collections.singletonList("now he is gone");
+        sut.train(input);
+        sut.initializeRandom(0);
+
+        // when
+        Sentence actual = sut.generateSentence();
+
+        // then
+        assertThat(actual.isDuplicate())
+                .as("expected sentence '%s' to be a duplicate.", actual.create())
+                .isTrue();
+    }
+
+    @Test
+    void generateSentenceShouldCreateAlternativeSentence() {
+        // given
+        List<String> input = Arrays.asList("now he is gone", "now he went insane");
+        sut.train(input);
+        sut.initializeRandom(0);
+
+        // when
+        Sentence actual = sut.generateSentence();
+
+        // then
+        assertThat(actual.isDuplicate())
+                .as("expected sentence '%s' to be a duplicate.", actual.create())
+                .isFalse();
+    }
+
+    @Test
+    void generateWithoutDuplicatesShouldQuitAfterThresholdAttempts() {
+        // given
+        List<String> input = Collections.singletonList("now he is gone");
+        sut.train(input);
+        sut.initializeRandom(0);
+
+        // when
+        String actual = sut.generateWithoutDuplicates();
+
+        // then
+        assertThat(actual).isEmpty();
+    }
+
+    @Test
+    void generateWithoutDuplicatesShouldCreateSentence() {
+        // given
+        List<String> input = Arrays.asList("now he is gone", "now he went insane", "now is the thime");
+        sut.train(input);
+
+        // when
+        String actual = sut.generateWithoutDuplicates();
+
+        // then
+        assertThat(actual).isNotEmpty();
     }
 
     @Test
@@ -189,7 +253,7 @@ class TweetkovChainTest {
         return createPrefix(2, tokens);
     }
 
-    private Prefix createPrefix_WS1(String... tokens) {
+    private Prefix prefix_WS1(String... tokens) {
         int windowSize = 1;
         return createPrefix(windowSize, tokens);
     }
@@ -200,5 +264,44 @@ class TweetkovChainTest {
             prefix.appendToken(token);
         }
         return prefix;
+    }
+
+    @Test
+    void isStartPrefixShouldReturnTrueOnFirst_windowsSize1() {
+        sut.setWindowSize(1);
+        boolean actual = sut.isStartPrefix(1);
+
+        assertThat(actual)
+                .as("expected value to be a start prefix for window size 1")
+                .isTrue();
+    }
+
+    @Test
+    void isStartPrefixShouldReturnTrueOnFirst_windowsSize2() {
+        sut.setWindowSize(2);
+        boolean actual = sut.isStartPrefix(2);
+
+        assertThat(actual)
+                .as("expected value to be a start prefix for window size 2")
+                .isTrue();
+    }
+
+    @Test
+    void createHistogramShouldReturn4Rows() {
+        // given
+        sut.setWindowSize(1);
+        String[] input = {"First Second Third", "First Lady Second That"};
+        sut.train(Arrays.asList(input));
+
+        // when
+        String actual = sut.createHistogram();
+
+        // then
+        String expected = "Lady: 1\n"
+                + "First: 2\n"
+                + "Second: 2\n"
+                + "Entries with 1 prefixes: 1\n"
+                + "Entries with 2 prefixes: 2\n";
+        assertThat(actual).isEqualTo(expected);
     }
 }


### PR DESCRIPTION
Implements Feature Request #2 - Adds support to remove duplicate sentences

Duplicate sentences arise from data where each link (aka Transition)
from prefix to suffix in the whole chain has the selection probability
of p=1.0 (all suffixes in that sentence are always selected).

This commit adds support to remove such sentences (aka "duplicates")
on a best effort basis. The idea is, to track transitions with a suffix
probability of p=1.0. During the sentence generation such a sentence can
be detected. Then a non-duplicate replace can be generated (aka
"alternative")

A retry mechanism takes care of avoiding sentences (in terms of the
contract of avoiding duplicates) in order to generate a sentence. If
during a retry a defined retry-threshold is hit then an warning is
logged and the method returns with an empty sentence.

There is still a high change that a duplicate can be generated. This is
because the original tweets are lost during the tokenization. The only
way to definitely know if a duplicate is at hand is the number of unique
transitions (as mentioned above). Once there is the sheer possibility to
select an alternative transition the whole sentence is viewed as
alternative.

Please note that the older method of generation (with duplicates) is
still active and running.

This commit moves the training data into its own repository class in
order to have a point of segregation so the actual implementation may
be exchanged. Transition is now the class which maps a prefix to any
number of suffixes.

Furthermore, a lot of logic moves from TweetkovChain into new classes
where the handling should belong. This also means that initializeSeed()
trails now through the chain of command in order to enable testing with
pseudo-random generators.

printHistogramm is converted to generateHistogram so users can decide
what to do with the histogram. It is still a single string though.